### PR TITLE
Flatten tag data

### DIFF
--- a/examples/examples/example_01.php
+++ b/examples/examples/example_01.php
@@ -6,9 +6,15 @@ require_once('../../vendor/autoload.php');
 $theData = [
     'firstname' => 'John',
     'lastname' => 'Doe',
+    'address' => [
+        'street' => 'Zonneveldweg',
+        'number' => '1',
+        'postalcode' => '3500',
+        'city' => 'Hasselt',
+    ],
 ];
 
-$theString = 'Hello my name is {{firstname}}.';
+$theString = 'Hello my name is {{firstname}}. I live in {{address.city}}';
 
 $dm = new DataMerge($theData);
 echo $dm->mergeStr($theString);

--- a/src/DataMerge.php
+++ b/src/DataMerge.php
@@ -27,6 +27,10 @@ class DataMerge
     public function setVars($vars)
     {
         $this->vars = [];
+
+        // Flatten array
+        $vars = $this->arrayToDot($vars);
+
         foreach ($vars as $tag => $value) {
             if (!is_array($value) && !is_object($value)) {
                 $this->vars[$tag] = strval($value);
@@ -189,5 +193,18 @@ class DataMerge
             }
         }
         return $string;
+    }
+
+    private function arrayToDot($array, $prepend = '')
+    {
+        $results = [];
+        foreach ($array as $key => $value) {
+            if (is_array($value) && ! empty($value)) {
+                $results = array_merge($results, $this->arrayToDot($value, $prepend.$key.'.'));
+            } else {
+                $results[$prepend.$key] = $value;
+            }
+        }
+        return $results;
     }
 }


### PR DESCRIPTION
Added ability to use arrays in tag data. The arrays get flattened to a dot notation.

### Example
This wil output: `Hello my name is John. I live in Hasselt`
```php
$theData = [
    'firstname' => 'John',
    'lastname' => 'Doe',
    'address' => [
        'street' => 'Zonneveldweg',
        'number' => '1',
        'postalcode' => '3500',
        'city' => 'Hasselt',
    ],
];

$theString = 'Hello my name is {{firstname}}. I live in {{address.city}}';

$dm = new DataMerge($theData);
echo $dm->mergeStr($theString);
```